### PR TITLE
Fix: send Content-Type header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,10 @@ class WinstonMattermostTransport extends Transport {
         const options = {
             hostname: this.url.hostname,
             path: this.url.pathname,
-            method: 'POST'
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            }
         };
 
         const req = https.request(options);


### PR DESCRIPTION
The mattermost api expects a "Content-Type"-header to be set when sending JSON in the request’s body. If that is not the case the notification cannot be processed and results in the error: "Could not decode the multipart payload of incoming webhook."

This gets fixed in this merge-request.